### PR TITLE
Args slicer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+1.1.9 -
+  * Add new ArgumentsSlicer module for processing `arguments` objects without causing deopt.
+  * Use slicer in FunctionBuilder where appropriate
+  * FunctionBuilder now has makeApplier helper, which replaces applyFn in
+    cases where you need to pass an arguments object
+  * FunctionBuilder no longer supports soak strings (but still supports direct
+    method names)
 1.1.8 - Fix bug with resolveObject
 1.1.7 - Remove object prototype underscore decoration, deprecated in favor of babel plugin
 1.1.6 - Rename memoize function builder to memoizeMethod in order to make it clear that it should not be used on bare functions

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ global.extendable = require('./lib/extendable');
 global.superExtendable = require('./lib/superExtendable');
 global.gettable = require('./lib/gettable');
 global.postExtendHookable = require('./lib/postExtendHookable');
+global.ArgumentsSlicer = require('./lib/argumentsSlicer');
 
 // Runtime function for the dot-underscore babel plugin
 require('./babel-plugins/dot-underscore-runtime');

--- a/lib/argumentsSlicer.js
+++ b/lib/argumentsSlicer.js
@@ -1,0 +1,173 @@
+// Efficient conversion of arguments to arrays, with slicing.
+//
+// Usage:
+//   let slicer = ArgumentsSlicer.make(1, -1);
+//
+//   let foo = function () {
+//     return slicer.apply(null, arguments);
+//   }
+//
+//  foo('a', 'b', 'c', 'd');
+//    --> ['b', 'c']
+//
+// Notes:
+//
+// - We sacrifice some syntax weirdness here to prevent deoptimization from
+//   passing around arguments, which is why you must call apply.
+// - This works best in the case where you have a _static_ slice operation
+//   (slice parameters known in advance), so that you can cache the slice
+//   function. A few common instances are also provided, which you should use
+//   whenever possible to help the optimizer with reuse.
+// - Calling ArgumentsSlicer.make dynamically in a function may still be better
+//   than using [].slice.call, but you're probably better off with a custom
+//   for loop.
+
+let ArgumentsSlicer = module.exports = {
+  // Create a function which will output an array from an arguments object,
+  // using the semantics as Array.prototype.slice
+  make: function (sliceStart, sliceEnd) {
+    // Note that we carefully restrict arguments operations throughout this method.
+
+    // This is the main workhorse which contains the loop over arguments. We
+    // give it our start and end, which may be computed from the arguments
+    // object itself, and we get back a function we can apply to execute the
+    // loop and copy into an array.
+    let makeLooper = function (start, end) {
+      if (start < 0) start = 0;
+
+      // We return a function rather than taking the arguments hash at this
+      // level, allowing us to preserve our restricted set of arguments operations
+      return function () {
+        let adjustedEnd = end;
+        if (end > arguments.length) adjustedEnd = arguments.length;
+
+        if (adjustedEnd <= start) return [];
+
+        // Allocate the array to the size we know we need
+        let array = new Array(adjustedEnd - start);
+        let insertIndex = 0;
+        for (let i = start; i < adjustedEnd; i++, insertIndex++) {
+          array[insertIndex] = arguments[i];
+        }
+
+        return array;
+      }
+    }
+
+    if (sliceStart == null) sliceStart = 0; // not really a special case
+    if (sliceStart < 0) { // start relative to length
+
+      // no explicit end
+      if (sliceEnd == null) {
+        return function () {
+          return makeLooper(arguments.length + sliceStart, arguments.length)
+            .apply(null, arguments);
+        }
+      }
+
+      // end relative to length
+      if (sliceEnd < 0) {
+        return function () {
+          return makeLooper(arguments.length + sliceStart, arguments.length + sliceEnd)
+            .apply(null, arguments);
+        }
+      }
+
+      // end indexed from beginning
+      return function () {
+        return makeLooper(arguments.length + sliceStart, sliceEnd)
+          .apply(null, arguments);
+      }
+    } else { // start indexed from beginning
+
+      // no explicit end
+      if (sliceEnd == null) {
+        return function () {
+          return makeLooper(sliceStart, arguments.length)
+            .apply(null, arguments);
+        }
+      }
+
+      // end relative to length
+      if (sliceEnd < 0) {
+        return function () {
+          return makeLooper(sliceStart, arguments.length + sliceEnd)
+            .apply(null, arguments);
+        }
+      }
+
+      // end indexed from beginning
+      return function () {
+        return makeLooper(sliceStart, sliceEnd).apply(null, arguments);
+      }
+    }
+  },
+}
+
+_.extend(ArgumentsSlicer, {
+  // simple tail; just omit first element
+  tail: ArgumentsSlicer.make(1),
+
+  // all but the last element
+  initial: ArgumentsSlicer.make(0, -1),
+
+  toArray: ArgumentsSlicer.make(),
+
+  last: function () {
+    return arguments[arguments.length - 1];
+  },
+
+  // Like array.map; fn gets item, index (but not arguments, because that would deopt)
+  // Usage: ArraySlicer.map(fn).apply(null, arguments);
+  map: function (fn) {
+    return function () {
+      let output = new Array(arguments.length);
+      for (let i = 0; i < arguments.length; i++) {
+        output[i] = fn(arguments[i], i)
+      }
+      return output;
+    }
+  },
+
+  // Usage: ArgumentsSlicer.each(fn).apply(null, arguments)
+  each: function (fn) {
+    return function () {
+      for (let i = 0; i < arguments.length; i++) {
+        fn(arguments[i], i)
+      }
+    }
+  },
+
+  // Usage: args = ArgumentsSlicer.concat([a, b], [c, d]).apply(null, argumetns) --> [a, b, ...arguments..., c, d]
+  concat: function (leadingItems, trailingItems) {
+    let leadingCount = leadingItems ? leadingItems.length : 0;
+    let trailingCount = trailingItems ? trailingItems.length : 0;
+
+    return function () {
+      let array = new Array(leadingCount + arguments.length + trailingCount);
+      let outputIndex = 0;
+
+      for (let i = 0; i < leadingCount; i++, outputIndex++) {
+        array[outputIndex] = leadingItems[i];
+      }
+
+      for (let i = 0; i < arguments.length; i++, outputIndex++) {
+        array[outputIndex] = arguments[i];
+      }
+
+      for (let i = 0; i < trailingCount; i++, outputIndex++) {
+        array[outputIndex] = trailingItems[i];
+      }
+
+      return array;
+    }
+  },
+
+  push: function (items) {
+    return ArgumentsSlicer.concat(null, items);
+  },
+
+  unshift: function (items) {
+    return ArgumentsSlicer.concat(items);
+  },
+})

--- a/lib/functionBuilder.js
+++ b/lib/functionBuilder.js
@@ -1,5 +1,8 @@
 var BaseObject = require('./baseObject');
 require('./proto/index');
+
+var ArgumentsSlicer = require('./argumentsSlicer');
+
 // FunctionBuilder is a toolset for manipulating functions by either calling
 // methods on a function object or by using the supplied FB global.
 //
@@ -15,7 +18,8 @@ require('./proto/index');
 // When an argument to a builder is another function, you can pass it a
 // string, which will be treated as a method name on the calling context.
 //  (when implementing custom functions, you must enable this behavior by calling the passed function
-//   using FunctionBuilder.applyFn(fn, context, args))
+//   using FunctionBuilder.makeApplier(fn, context).apply(fn, arguments)) or FunctionBuilder.applyFn(fn, context, args)
+//   (prefer the former if you have an arguments object, since it won't deopt in v8)
 //
 // Available transforms:
 //   q - Forces the function to return a promise.  This way inside the function
@@ -111,10 +115,14 @@ var FunctionBuilder = module.exports = BaseObject.extend({
   pairsOrAttrs: function (fn) {
     var argCount = getOriginal(fn).length;
     var headArgs = argCount - 1;
+    let headSlicer = ArgumentsSlicer.make(0, headArgs);
+    let restSlicer = ArgumentsSlicer.make(headArgs);
+
     return function () {
       var self = this;
-      var args = _.head(arguments, headArgs);
-      var keysAndValues = _.rest(arguments, headArgs);
+      var args = headSlicer.apply(null, arguments);
+
+      var keysAndValues = restSlicer.apply(null, arguments);
       var attrs;
       if (keysAndValues.length === 1) { // Called with object
         attrs = keysAndValues[0];
@@ -134,23 +142,24 @@ var FunctionBuilder = module.exports = BaseObject.extend({
   },
 
   wrap: function (originalFn, wrapperFn) {
+    let slicer = ArgumentsSlicer.unshift([originalFn]);
     return function () {
-      var args = _.toArray(arguments);
-      return applyFn(wrapperFn, this, [originalFn].concat(args)); // eslint-disable-line fieldbook/no-nested-this
+      var args = slicer.apply(null, arguments);
+      return applyFn(wrapperFn, this, args); // eslint-disable-line fieldbook/no-nested-this
     }
   },
 
   after: function (originalFn, afterFn) {
     return function () {
       var result = originalFn.apply(this, arguments); // eslint-disable-line fieldbook/no-nested-this
-      applyFn(afterFn, this, arguments); // eslint-disable-line fieldbook/no-nested-this
+      makeApplier(afterFn, this).apply(null, arguments); // eslint-disable-line fieldbook/no-nested-this
       return result;
     }
   },
 
   before: function (originalFn, beforeFn) {
     return function () {
-      applyFn(beforeFn, this, arguments); // eslint-disable-line fieldbook/no-nested-this
+      makeApplier(beforeFn, this).apply(null, arguments); // eslint-disable-line fieldbook/no-nested-this
       return originalFn.apply(this, arguments); // eslint-disable-line fieldbook/no-nested-this
     }
   },
@@ -159,7 +168,7 @@ var FunctionBuilder = module.exports = BaseObject.extend({
     return function () {
       var self = this;
       var result = originalFn.apply(self, arguments);
-      return applyFn(chainedFn, self, [result, _.toArray(arguments)]);
+      return applyFn(chainedFn, self, [result, ArgumentsSlicer.toArray.apply(null, arguments)]);
     }
   },
 
@@ -190,7 +199,7 @@ var FunctionBuilder = module.exports = BaseObject.extend({
       var originalHashFn = hashFn
       hashFn = function () {
         var self = this;
-        var hash = applyFn(originalHashFn, self, arguments);
+        var hash = makeApplier(originalHashFn, self).apply(null, arguments);
         if (_.isObject(hash) || _.isArray(hash)) return JSON.stringify(hash);
         return hash;
       }
@@ -218,11 +227,17 @@ var FunctionBuilder = module.exports = BaseObject.extend({
 
 // Like apply, but fn can be a method name
 var applyFn = FunctionBuilder.applyFn = function (fn, context, args) {
-  if (_.isString(fn)) {
-    var path = fn;
-    return _.soakApply(context, path, args);
-  } else {
-    return fn.apply(context, args);
+  return makeApplier(fn, context).apply(null, args);
+}
+
+// Make a function that you can call apply on, may be a function or a method
+// name (used to prevent deoptimization from arguments usage)
+//
+// Use like: makeApplier(fnOrName, this).apply(null, arguments);
+var makeApplier = FunctionBuilder.makeApplier = function (fn, context) {
+  if (_.isString(fn)) fn = context[fn];
+  return function () {
+    return fn.apply(context, arguments);
   }
 }
 
@@ -234,7 +249,7 @@ _.each(['then', 'fail', 'spread', 'finally', 'tap'], function (promiseMethod) {
     return function () {
       var self = this;
       return fn.apply(self, arguments)[promiseMethod](function () {
-        return applyFn(callback, self, arguments);
+        return makeApplier(callback, self).apply(null, arguments);
       });
     }
   }
@@ -266,7 +281,7 @@ var functionPrototype = Function.prototype;
 var addToFunctionPrototype = function (name) {
   functionPrototype[name] = function () {
     var fn = this;
-    var args = [fn].concat(_.toArray(arguments));
+    var args = ArgumentsSlicer.unshift([fn]).apply(null, arguments);
     return decorateWithOriginal(builder[name].apply(builder, args), fn);
   }
 }
@@ -289,7 +304,7 @@ var ChainedBuilder = BaseObject.extend({
 var addToChainBuilder = function (name) {
   ChainedBuilder.prototype[name] = function () {
     var self = this;
-    self.transformers.push({name: name, args: _.toArray(arguments)});
+    self.transformers.push({name: name, args: ArgumentsSlicer.toArray.apply(null, arguments)});
     return self;
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intrusive",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "a set of intrusive javascript modules, not for use in libraries",
   "main": "index.js",
   "scripts": {

--- a/test/argumentsSlicer.js
+++ b/test/argumentsSlicer.js
@@ -1,0 +1,133 @@
+var ArgumentsSlicer = require('../lib/argumentsSlicer');
+
+describe('Arguments slicer', function () {
+  // Test specific methods
+  it('should tail arguments correctly', function () {
+    let fn = function () {
+      return ArgumentsSlicer.tail.apply(null, arguments);
+    }
+
+    expect(fn()).deep.equal([]);
+    expect(fn(1)).deep.equal([]);
+    expect(fn(1, 2, 3)).deep.equal([2, 3]);
+  })
+
+  it('should initial arguments correctly', function () {
+    let fn = function () {
+      return ArgumentsSlicer.initial.apply(null, arguments);
+    }
+
+    expect(fn()).deep.equal([]);
+    expect(fn(1)).deep.equal([]);
+    expect(fn(1, 2, 3)).deep.equal([1, 2]);
+  })
+
+  it('should last arguments correctly', function () {
+    let fn = function () {
+      return ArgumentsSlicer.last.apply(null, arguments);
+    }
+
+    expect(fn()).equal(undefined);
+    expect(fn(1)).equal(1);
+    expect(fn('a', 'b')).equal('b');
+  })
+
+  it('should map arguments correctly', function () {
+    let fn = function () {
+      return ArgumentsSlicer.map(x => x + 1).apply(null, arguments);
+    }
+
+    expect(fn()).deep.equal([]);
+    expect(fn(1)).deep.equal([2]);
+    expect(fn(1, 2, 3)).deep.equal([2, 3, 4]);
+  })
+
+  it('should each arguments correctly', function () {
+    let fn = function () {
+      let result = 0
+      ArgumentsSlicer.map(x => { result += x }).apply(null, arguments);
+      return result;
+    }
+
+    expect(fn()).equal(0);
+    expect(fn(1)).equal(1);
+    expect(fn(1, 2, 3)).equal(6);
+  })
+
+  it('should concat arguments correctly', function () {
+    let fn = function () {
+      return ArgumentsSlicer.concat([1, 2], [3, 4]).apply(null, arguments);
+    }
+
+    expect(fn()).deep.equal([1, 2, 3, 4]);
+    expect(fn('a')).deep.equal([1, 2, 'a', 3, 4]);
+    expect(fn('a', 'b', 'c')).deep.equal([1, 2, 'a', 'b', 'c', 3, 4]);
+  })
+
+  it('should push arguments correctly', function () {
+    let fn = function () {
+      return ArgumentsSlicer.push([3, 4]).apply(null, arguments);
+    }
+
+    expect(fn()).deep.equal([3, 4]);
+    expect(fn('a')).deep.equal(['a', 3, 4]);
+    expect(fn('a', 'b', 'c')).deep.equal(['a', 'b', 'c', 3, 4]);
+  })
+
+  it('should unshift arguments correctly', function () {
+    let fn = function () {
+      return ArgumentsSlicer.unshift([1, 2]).apply(null, arguments);
+    }
+
+    expect(fn()).deep.equal([1, 2]);
+    expect(fn('a')).deep.equal([1, 2, 'a']);
+    expect(fn('a', 'b', 'c')).deep.equal([1, 2, 'a', 'b', 'c']);
+  })
+
+  // Use [].slice as a reference implementation
+  describe('comparison to Array.prototype.slice', function () {
+    let argsCases = [
+      [],
+      ['zoo'],
+      ['a', 'b'],
+      [1, 2, 3, 4],
+      'foo bar baz qux gribble gralt'.split(' '),
+    ];
+
+    let sliceArgsCases = [
+      [],
+      [1],
+      [-1],
+      [-3, -1],
+      [0, -1],
+      [1, 5],
+      [3, 2],
+      [2, 5],
+      [2, -1],
+      [20, -90],
+      [20, 90],
+      [-50, -100],
+      [-100, -50],
+    ];
+
+    for (let sliceArgs of sliceArgsCases) {
+      describe(`with slicer arguments ${JSON.stringify(sliceArgs)}`, function () { // eslint-disable-line no-loop-func
+        let slicer = ArgumentsSlicer.make(...sliceArgs);
+        let actual = function () {
+          return slicer.apply(null, arguments);
+        }
+
+        let expected = function (args) {
+          return args.slice(...sliceArgs);
+        }
+
+        for (let args of argsCases) {
+          let expectation = expected(args);
+          it(`should slice [${args}] correctly as [${expectation}]`, function () { // eslint-disable-line no-loop-func
+            expect(actual(...args)).deep.equal(expectation);
+          })
+        }
+      })
+    }
+  })
+})

--- a/test/functionBuilder.js
+++ b/test/functionBuilder.js
@@ -510,40 +510,4 @@ describe('Function Builder', function () {
       return expect(obj.setByBar).equal('fooCalled');
     })
   })
-
-  describe('when you pass in a soak path instead of a function', function () {
-    var obj;
-
-    before(function () {
-      obj = {
-        foo: function () {
-          var self = this;
-          self.child.state = 'fooCalled';
-        }.after('child.bar'),
-
-        child: {
-          state: 'initial',
-
-          bar: function () {
-            var self = this;
-            self.setByBar = self.state;
-          },
-        },
-      }
-
-      obj.foo();
-    })
-
-    it('should call foo', function () {
-      return expect(obj.child.state).equal('fooCalled');
-    })
-
-    it('should call child.bar', function () {
-      return expect(obj.child.setByBar).not.undefined;
-    })
-
-    it('should call in the correct order', function () {
-      return expect(obj.child.setByBar).equal('fooCalled');
-    })
-  })
 })


### PR DESCRIPTION
See changes.

In adapting ArgumentSlicer, I also added `concat`, `push` and `unshift` helpers to further reduce array allocation overhead.